### PR TITLE
Darkmode: OLED-optimiert mit lebendigeren Farben

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,16 @@
 
     @media (prefers-color-scheme: dark) {
       :root {
-        --bg:        #1a1410;
-        --surface:   #221c16;
-        --card:      #2a221a;
-        --border:    #3d3028;
-        --accent:    #e8925f;
-        --accent-bg: #2d1f14;
-        --text:      #f5ede4;
-        --muted:     #a89080;
-        --hint:      #6a5a50;
+        --bg:        #000000;
+        --surface:   #0a0806;
+        --card:      #0f0b08;
+        --border:    #ff6020;
+        --accent:    #ff7030;
+        --accent-bg: #1a0e04;
+        --text:      #fff8f2;
+        --muted:     #c8a888;
+        --hint:      #806858;
+        --shadow:    0 2px 12px rgba(255,100,30,0.12);
       }
     }
 


### PR DESCRIPTION
Passt das Farbschema des Darkmodes an:

- Hintergründe nahezu echtschwarz für OLED-Energiesparen
- Heller Text (#fff8f2) für hohen Kontrast
- Ränder und Akzente in sattem Orange (#ff6020 / #ff7030)

Schließt Issue #6

Generated with [Claude Code](https://claude.ai/code)